### PR TITLE
Update Password_reset.php

### DIFF
--- a/src/models/Password_reset.php
+++ b/src/models/Password_reset.php
@@ -15,4 +15,5 @@ class Password_reset extends Model
 {
     public $timestamps = false;
     protected $dates = ['created_at'];
+    protected $primaryKey = 'email';
 }


### PR DESCRIPTION
When the controller wants to update the 'created_at' time stamp it fails, because Laravel is normally searching for a ID but it doesn't have a ID. So if you set the primary key to 'email' it will ignore that.
